### PR TITLE
Ability to set auto-generate tasks frequency.

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -42,7 +42,7 @@
                 </div>
                 <span> Messages until next AI task completion check <span id="objective-counter">0</span></span>
                 <br>
-                <span> Messages until next AI tasks regeneration <span id="objective-counter">0</span></span>
+                <span> Messages until next AI tasks regeneration <span id="generate-counter">0</span></span>
                 <div class="objective_block flex-container">
                     <input id="objective_prompt_edit" class="menu_button" type="submit" value="Edit Prompts" />
                 </div>

--- a/settings.html
+++ b/settings.html
@@ -29,13 +29,20 @@
                     </div>
                     <br>
                     <div class="objective_block objective_block_control flex1">
-
                         <label for="objective-check-frequency">Task Check Frequency</label>
                         <input id="objective-check-frequency" class="text_pole widthUnset" type="number" min="0" max="99" />
                         <small>(0 = disabled)</small>
                     </div>
+                    <br>
+                    <div class="objective_block objective_block_control flex1">
+                        <label for="objective-generate-frequency">Auto-Generate Frequency</label>
+                        <input id="objective-generate-frequency" class="text_pole widthUnset" type="number" min="0" max="99" />
+                        <small>(0 = disabled)</small>
+                    </div>
                 </div>
                 <span> Messages until next AI task completion check <span id="objective-counter">0</span></span>
+                <br>
+                <span> Messages until next AI tasks regeneration <span id="objective-counter">0</span></span>
                 <div class="objective_block flex-container">
                     <input id="objective_prompt_edit" class="menu_button" type="submit" value="Edit Prompts" />
                 </div>

--- a/style.css
+++ b/style.css
@@ -3,6 +3,11 @@
     color: orange;
 }
 
+#generate-counter {
+    font-weight: 600;
+    color: orange;
+}
+
 .objective_block {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Hi! ^_^
Here is why and here is how.

### Why:
First. Because without it the dialog could easily fall into a trapped state.
For example, let's say there is a subtask `Make the {{user}} take an umbrella.`
And there is an actual dialog:
```
> AI: "Hey, those clouds look shifty — maybe grab an umbrella?"
> User: "Nah, let the sky try me."
```
And that's it. Bad.
Next it will follow one of those paths (depending on the context, model, and Position in Chat value):
- Stuck: will never mention it in dialog, will never mark it as done.
- Overzealous: will repeatedly try something "Take an umbrella with you. Seriously, take it. You must take it. I still insist you take it."
- Confused: if for some reason task will be marked as done (after a dozen of AI checks due to some random noise), and the next task relies on the presence of such umbrella, it could materialize it out of a thin air or lead to some logic gibberish.

Second. Because dialog could naturally flow to some another context, where the generated tasks are no longer relevant. For example, they were generated in some strictly indoor context, and the dialog moved outdoor.

Third. It is helpful for creating moving (shifting / following) tasks without strict end goal. Something like "generate some challenges for the {{user}} given the current state".

### How:
Here, I am not sure I understood correctly the part with "Don't let counter go negative".
I removed the comment (sorry about that =), and moved counter re-initialization from the separate function right in place.
And did the same for the new counter. Seems to work with zero and non-zero case, but maybe I missed something?